### PR TITLE
Added timestamp_latestdata_lox, usable to detect stale data.

### DIFF
--- a/webfrontend/htmlauth/vitoconnect.php
+++ b/webfrontend/htmlauth/vitoconnect.php
@@ -265,6 +265,7 @@ function Viessmann_summary( $login ){
 	$Install->detail-> timestamp = date('r',time());
 	
 	$installationDetailEntity = json_decode($installationDetailJson, false);
+	$latestEpochTimeFoundInData=0; //store the latest time found within the data itself. Some change quite seldomly, while e.g. outside temperature changes frequently
 	
 	foreach($installationDetailEntity->data as $entity){		
 		$DetailEntity = $entity;	
@@ -273,6 +274,10 @@ function Viessmann_summary( $login ){
 			$Key = $entity->feature;
 			$Key = $Key.".".$key;
 			$type =  $value->type;
+			$currentDateTimeFeature = DateTime::createFromFormat('Y-m-d\TH:i:s.u\Z', $entity->timestamp, new DateTimeZone('UTC'))->getTimestamp(); // fun fact that DateTime::ISO8601 does not work with fraction of seconds
+			if ($currentDateTimeFeature > $latestEpochTimeFoundInData) {
+				$latestEpochTimeFoundInData = $currentDateTimeFeature;
+			}
 			
 				switch($type) {
 					
@@ -313,7 +318,7 @@ function Viessmann_summary( $login ){
 				$Install->detail->$Key=$Value;
 		}
 	}
-	
+	$Install->detail-> timestamp_latestdata_lox = epoch2lox($latestEpochTimeFoundInData);
 	
 	$detailcontent  = json_encode($Install);
 	$detailcontent  = json_decode($detailcontent,true);


### PR DESCRIPTION
In order to detect stale data in Loxone, a timestamp generated by Vitoconnect is helpful.

Therefore I added some logic to find out the latest timestamp inside the data. Interestingly, the timestamps are written per datum and highly vary, depending on the data point. While I had a look at the data, the latest timestamp was often coming from the temperature sensor.
The timestamp is converted to loxone epoch time and can be used to compute an age within loxone and alert if the age is higher than e.g. 1 hour.